### PR TITLE
ツアーの確認画面を作成、合わせてツアーのルート最適化に関する修正を一部開始

### DIFF
--- a/app/Controller/PlayController.php
+++ b/app/Controller/PlayController.php
@@ -225,9 +225,12 @@ class PlayController extends Controller
 	private function __findTourDirection($lat, $lng, $tour_id)
 	{
 		// ツアーに含まれるスポットを取得する
-		$tourSpotRels= $this->TourSpotRels->find('all', array('conditions' => array(
-			'tour_id' => $tour_id
-		)));
+		$tourSpotRels= $this->TourSpotRels->find('all',
+			array(
+				'conditions' => array('tour_id' => $tour_id),
+				'order' => array('spot_order' => 'asc')
+			)
+		);
 
 		// 経由地
 		$waypoints = array();
@@ -380,7 +383,7 @@ class PlayController extends Controller
 
 		//API結果判定 20km以上はなれている場合はlistへリダイレクト
 		$res_json = json_decode($res);
-		if ( strstr($res_json->routes[0]->legs[0]->distance->text,"km") && 
+		if ( strstr($res_json->routes[0]->legs[0]->distance->text,"km") &&
              str_replace(" km", "", $res_json->routes[0]->legs[0]->distance->text) >= 20 ) {
 			$this->redirect('/list');
 		}

--- a/app/View/Manage/index.ctp
+++ b/app/View/Manage/index.ctp
@@ -4,10 +4,19 @@
         <h4>こちらのページでは、スポットの登録とツアーの登録ができます。以下のボタンから各登録画面へ進んでください。</h4>
         <br>
         <div class="jumbotron">
+            <div style="text-align:center">
+                <h4>スポットの管理</h4>
+            </div>
+            <hr>
             <a class="btn btn-info btn-lg" href="/manage/addspot" style="width:100%;">スポットを登録する</a>
             <a class="btn btn-info btn-lg" href="/manage/delspot" style="width:100%;">スポットを削除する</a>
         </div>
         <div class="jumbotron">
+            <div style="text-align:center">
+                <h4>ツアーの管理</h4>
+            </div>
+            <hr>
+            <a class="btn btn-info btn-lg" href="/manage/showtour" style="width:100%;">ツアーを確認する</a>
             <a class="btn btn-info btn-lg" href="/manage/addtour" style="width:100%;">ツアーを登録する</a>
         </div>
     </div>

--- a/app/View/Manage/showtour.ctp
+++ b/app/View/Manage/showtour.ctp
@@ -1,0 +1,17 @@
+<div class="container">
+    <div class="jumbotron">
+      <h4><i class="mdi-action-explore"></i> ツアーをえらんでぶらり</h4>
+      <hr>
+      <div class="list-group">
+        <?php for($i = 0; $i < count($tours); $i++){ ?>
+          <a class="list-group-item btn btn-defaul btn-raised" href="showtourdetail?tour_id=<?php echo $tours[$i]['Tour']['id']?>">
+              <div style="background-color: rgba(255,255,255,0.3); margin-left:-100px; margin-right:-100px;">
+                <h5 class="list-group-item-heading" style="color: #222;">
+                    <?php echo $tours[$i]['Tour']['name'] ?>
+                </h5>
+              </div>
+          </a>
+          <?php } ?>
+      </div>
+    </div>
+</div>

--- a/app/View/Manage/showtourdetail.ctp
+++ b/app/View/Manage/showtourdetail.ctp
@@ -1,0 +1,173 @@
+<script src="https://maps.googleapis.com/maps/api/js?v=3.exp"></script>
+<script type="text/javascript">
+    var directionsDisplay;
+    var directionsService = new google.maps.DirectionsService();
+    var map;
+
+    function initialize() {
+        directionsDisplay = new google.maps.DirectionsRenderer();
+        var center = new google.maps.LatLng(<?php echo $start_lat ?>,<?php echo $start_lng?>);
+        var mapOptions = {
+            zoom: 9,
+            center: center
+        }
+        map = new google.maps.Map(document.getElementById('map-canvas'), mapOptions);
+        directionsDisplay.setMap(map);
+    }
+
+    function calcRoute() {
+        //経由地設定
+        var waypts = [];
+            <?php
+                for ($i = 0; $i < $num_of_waypoints ; $i++){
+                    echo "  waypts.push({\n";
+                    echo "      location: '$waypoints[$i]',\n";
+                    echo "      stopover:true\n";
+                    echo "  });\n";
+                }
+            ?>
+
+        //経由地通過ルートの最適化判定
+        var routeOptimized = true;
+        <?php if($tour_route_optimized == 0){ ?>
+            routeOptimized = false;
+        <?php }; ?>
+
+        //地図リクエスト用オブジェクト生成
+        var request = {
+            origin: '<?php echo $start_lat . "," . $start_lng ?>',
+            //origin: '元町・中華街',
+            destination: '<?php echo $end_lat . "," . $end_lng ?>',
+            waypoints: waypts,
+            unitSystem: google.maps.DirectionsUnitSystem.METRIC,
+            optimizeWaypoints: routeOptimized,
+            avoidTolls:true,
+            travelMode: google.maps.TravelMode.WALKING
+        };
+
+        directionsService.route(request, function(response, status) {
+            if (status == google.maps.DirectionsStatus.OK) {
+                directionsDisplay.setDirections(response);
+            }else{
+                sweetAlert('request failed: ' + status);
+            }
+        });
+
+        /*
+        //経由地の設定が、８個が上限であることへの対策
+        //リクエストを複数回実施して、結果を結合して描画する（2015/8/30：未完成）
+        var org_start = '<?php echo $start_lat . "," . $start_lng ?>';
+        var org_end = '<?php echo $end_lat . "," . $end_lng ?>';
+        var unit = 10;
+        var result;
+        var push = Array.prototype.push;
+        var next_waypts;
+        for(var wp = 0; wp <= waypts.length;){
+            var next_start = org_start;
+            var next_end = org_end;
+            var next_start_wp = 0;
+            var next_end_wp = waypts.length - 1;
+
+            //二回目以降のループでのスタート地点設定
+            if(wp > 0){
+                next_start = waypts[wp].location;
+                next_start_wp = wp + 1;
+            }
+
+            //最終目的地が次のゴール地点ではない場合のゴール地点設定
+            if(wp + unit < waypts.length){
+                next_end = waypts[wp+unit-1].location;
+                next_end_wp = wp + unit - 2
+            }
+
+            //最終目的地が次のゴール地点ではない場合の経由地設定
+            if(next_start_wp != 0 || next_end_wp != 0){
+                next_waypts = waypts.slice(next_start_wp, next_end_wp);
+            }else{
+                next_waypts = waypts;
+            }
+
+            //地図リクエスト用オブジェクト生成
+            var request = {
+                //origin: next_start,
+                origin: '元町・中華街',
+                destination: next_end,
+                waypoints: next_waypts,
+                optimizeWaypoints: true,
+                travelMode: google.maps.TravelMode.WALKING
+            };
+
+            //リクエスト
+            directionsService.route(request, function(response, status) {
+                if (status == google.maps.DirectionsStatus.OK) {
+                    if(!result){
+                        //最初のリクエストの場合には、ルートを持つオブジェクトを保持
+                        result = response;
+                    }else{
+                        //二回目以降のリクエストの場合には、ルートを追加
+                        /*
+                        result.routes[0].legs = push.apply(result.routes[0].legs, response.routes[0].legs);
+                        result.routes[0].overview_path = push.apply(result.routes[0].overview_path, response.routes[0].overview_path);
+                        result.routes[0].bounds = result.routes[0].bounds.extend(response.routes[0].bounds.getNorthEast());
+                        result.routes[0].bounds = result.routes[0].bounds.extend(response.routes[0].bounds.getSouthWest());
+                        */
+                /*    }
+
+                    //最後のリクエストの場合には、描画
+                    if(wp + unit >= waypts.length){
+                        directionsDisplay.setDirections(result);
+                    }
+                }else{
+                    sweetAlert('request failed: ' + status);
+                }
+            });
+            //wp = wp + unit;
+            wp = waypts.length;
+        };
+        */
+    }
+
+
+    google.maps.event.addDomListener(window, 'load', initialize);
+
+    $(document).ready(function () {
+        setTimeout(function(){calcRoute()},500);
+    });
+
+    $(window).on('load', function(){
+        var w = $(window).width() * 0.9;
+        $('div#map-canvas').attr('width', w);
+    });
+
+</script>
+
+<div class="container">
+
+    <div class="panel panel-info">
+        <div class="panel-heading"><i class="mdi-maps-place"></i>　ツアー名</div>
+        <div class="panel-body">
+            <h3><?php echo $tour_name?></h3>
+        </div>
+    </div>
+
+    <div class="panel panel-info">
+        <div class="panel-heading"><i class="mdi-maps-place"></i>　ツアー説明</div>
+        <div class="panel-body">
+            <h4><?php echo $tour_description?></h4>
+        </div>
+    </div>
+
+    <div class="panel panel-info">
+        <div class="panel-heading"><i class="mdi-maps-place"></i>　登録したツアーのルート例</div>
+        <div class="panel-body">
+            <p>このルートは一例となります。ユーザーがツアーを始める位置によってルートは若干異なる可能性があります。</p>
+            <div id="map-canvas" style="height:400px"></div>
+            </div>
+    </div>
+
+    <div style="text-align:center;">
+        <a class="btn btn-info btn-lg" href="/manage/showtour" style="width:100%;" id="add-button">ツアー一覧へ戻る</a>
+        <a class="btn btn-info btn-lg" href="/manage/" style="width:100%;" id="add-button">管理画面トップへ戻る</a>
+    </div>
+
+</div>


### PR DESCRIPTION
ナイトビューウォークに向けてツアーの登録及びその結果を確認できるように修正。
なお、Playの一部にも修正を入れており、恒久対応としたい内容だが、別で動いているPlayの画面修正もあるため、マージ時には注意が必要となる。
Playに関しての修正は、Playでのツアーのルート取得方式がGoogleへは最適化オプションがついていなかったために、一旦DBから取得する経由地の順番を制御するためにorder句をつけたのみである。
※合わせてDBにorderが効くように、項目を追加している

まずは、ナイトビューウォークに向けて、承認お願いします
